### PR TITLE
Color code union membership density badges

### DIFF
--- a/src/components/employers/EmployerCard.tsx
+++ b/src/components/employers/EmployerCard.tsx
@@ -9,6 +9,7 @@ import { getEbaStatusInfo } from "./ebaHelpers";
 import { useNavigate } from "react-router-dom";
 import { useState } from "react";
 import { EbaAssignmentModal } from "./EbaAssignmentModal";
+import { getProgressIndicatorClass } from "@/utils/densityColors";
 
 type EmployerWithEba = {
   id: string;
@@ -169,7 +170,7 @@ export const EmployerCard = ({ employer, onClick }: EmployerCardProps) => {
                   <span>Member Density</span>
                   <span>{analytics.member_density_percent}%</span>
                 </div>
-                <Progress value={analytics.member_density_percent} className="h-2" />
+                <Progress value={analytics.member_density_percent} className="h-2" indicatorClassName={getProgressIndicatorClass(analytics.member_density_percent)} />
               </div>
             )}
 
@@ -179,7 +180,7 @@ export const EmployerCard = ({ employer, onClick }: EmployerCardProps) => {
                   <span>Est. Density ({analytics.estimated_worker_count} total)</span>
                   <span>{analytics.estimated_density_percent}%</span>
                 </div>
-                <Progress value={analytics.estimated_density_percent} className="h-2" />
+                <Progress value={analytics.estimated_density_percent} className="h-2" indicatorClassName={getProgressIndicatorClass(analytics.estimated_density_percent)} />
               </div>
             )}
 

--- a/src/components/ui/progress.tsx
+++ b/src/components/ui/progress.tsx
@@ -3,10 +3,14 @@ import * as ProgressPrimitive from "@radix-ui/react-progress"
 
 import { cn } from "@/lib/utils"
 
+interface ProgressProps extends React.ComponentPropsWithoutRef<typeof ProgressPrimitive.Root> {
+  indicatorClassName?: string;
+}
+
 const Progress = React.forwardRef<
   React.ElementRef<typeof ProgressPrimitive.Root>,
-  React.ComponentPropsWithoutRef<typeof ProgressPrimitive.Root>
->(({ className, value, ...props }, ref) => (
+  ProgressProps
+>(({ className, value, indicatorClassName, ...props }, ref) => (
   <ProgressPrimitive.Root
     ref={ref}
     className={cn(
@@ -16,7 +20,7 @@ const Progress = React.forwardRef<
     {...props}
   >
     <ProgressPrimitive.Indicator
-      className="h-full w-full flex-1 bg-primary transition-all"
+      className={cn("h-full w-full flex-1 bg-primary transition-all", indicatorClassName)}
       style={{ transform: `translateX(-${100 - (value || 0)}%)` }}
     />
   </ProgressPrimitive.Root>

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -5,6 +5,7 @@ import { Badge } from "@/components/ui/badge";
 import { useDashboardData } from "@/hooks/useDashboardData";
 import { Skeleton } from "@/components/ui/skeleton";
 import { PieChart, Pie, Cell, ResponsiveContainer, BarChart, Bar, XAxis, YAxis, Tooltip } from "recharts";
+import { getProgressIndicatorClass } from "@/utils/densityColors";
 
 const Dashboard = () => {
   const { data, isLoading } = useDashboardData();
@@ -234,7 +235,7 @@ const Dashboard = () => {
               <span>Overall Membership Rate</span>
               <span>{data?.membershipRate?.toFixed(1) || 0}%</span>
             </div>
-            <Progress value={data?.membershipRate || 0} className="h-2" />
+            <Progress value={data?.membershipRate || 0} className="h-2" indicatorClassName={getProgressIndicatorClass(data?.membershipRate || 0)} />
           </div>
           
           <div>
@@ -242,7 +243,7 @@ const Dashboard = () => {
               <span>Average Member Density (Mapped Employers)</span>
               <span>{data?.avgMemberDensity?.toFixed(1) || 0}%</span>
             </div>
-            <Progress value={data?.avgMemberDensity || 0} className="h-2" />
+            <Progress value={data?.avgMemberDensity || 0} className="h-2" indicatorClassName={getProgressIndicatorClass(data?.avgMemberDensity || 0)} />
           </div>
 
           <div className="grid grid-cols-2 gap-4 pt-4">

--- a/src/pages/PatchWall.tsx
+++ b/src/pages/PatchWall.tsx
@@ -7,6 +7,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { EmployerWorkerChart } from "@/components/patchwall/EmployerWorkerChart";
+import { getDensityBadgeClass } from "@/utils/densityColors";
 const setMeta = (title: string, description: string, canonical?: string) => {
   document.title = title;
   const metaDesc = document.querySelector('meta[name="description"]');
@@ -28,9 +29,7 @@ const setMeta = (title: string, description: string, canonical?: string) => {
 
 const densityBadge = (pct?: number | null) => {
   const v = typeof pct === 'number' ? pct : 0;
-  if (v >= 60) return <Badge variant="default">{v}%</Badge>;
-  if (v >= 30) return <Badge variant="secondary">{v}%</Badge>;
-  return <Badge variant="destructive">{v}%</Badge>;
+  return <Badge className={getDensityBadgeClass(v)}>{v}%</Badge>;
 };
 
 const PatchWall = () => {

--- a/src/utils/densityColors.ts
+++ b/src/utils/densityColors.ts
@@ -1,0 +1,38 @@
+export const getDensityColor = (pct: number | null | undefined) => {
+  const value = typeof pct === 'number' ? pct : 0;
+  if (value > 75) return 'navy';
+  if (value >= 50) return 'green';
+  if (value >= 25) return 'orange';
+  return 'red';
+};
+
+export const getDensityBadgeClass = (pct: number | null | undefined) => {
+  const color = getDensityColor(pct);
+  // Solid backgrounds with white text per requirements
+  switch (color) {
+    case 'navy':
+      return 'border-transparent bg-blue-900 text-white hover:bg-blue-900';
+    case 'green':
+      return 'border-transparent bg-green-600 text-white hover:bg-green-600';
+    case 'orange':
+      return 'border-transparent bg-orange-500 text-white hover:bg-orange-500';
+    case 'red':
+    default:
+      return 'border-transparent bg-red-600 text-white hover:bg-red-600';
+  }
+};
+
+export const getProgressIndicatorClass = (pct: number | null | undefined) => {
+  const color = getDensityColor(pct);
+  switch (color) {
+    case 'navy':
+      return 'bg-blue-900';
+    case 'green':
+      return 'bg-green-600';
+    case 'orange':
+      return 'bg-orange-500';
+    case 'red':
+    default:
+      return 'bg-red-600';
+  }
+};


### PR DESCRIPTION
Implement a color-coding scheme for union membership density displays to visually categorize density levels.

---
<a href="https://cursor.com/background-agent?bcId=bc-6645e699-ccfa-4f05-ad4c-f3ad8be325a8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6645e699-ccfa-4f05-ad4c-f3ad8be325a8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

