### PR TITLE
Add organiser allocations to projects

### DIFF
--- a/src/pages/ProjectDetail.tsx
+++ b/src/pages/ProjectDetail.tsx
@@ -18,6 +18,8 @@ import ContractorsSummary from "@/components/projects/ContractorsSummary";
 import { EmployerDetailModal } from "@/components/employers/EmployerDetailModal";
 import { EbaAssignmentModal } from "@/components/employers/EbaAssignmentModal";
 import { EbaEditDatesModal } from "@/components/employers/EbaEditDatesModal";
+import { useAuth } from "@/hooks/useAuth";
+import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from "@/components/ui/select";
 const setMeta = (title: string, description: string, canonical?: string) => {
   document.title = title;
   const metaDesc = document.querySelector('meta[name="description"]');
@@ -39,6 +41,7 @@ const setMeta = (title: string, description: string, canonical?: string) => {
 
 const ProjectDetail = () => {
   const { id } = useParams<{ id: string }>();
+  const { user } = useAuth();
 
   useEffect(() => {
     setMeta(
@@ -64,6 +67,71 @@ const ProjectDetail = () => {
       return data as any;
     },
   });
+
+  // Fetch current organiser allocations for this project
+  const { data: organiserAllocations = [], refetch: refetchAllocations } = useQuery({
+    queryKey: ["project-organiser-allocations", id],
+    enabled: !!id,
+    queryFn: async () => {
+      const { data, error } = await supabase
+        .from("organiser_allocations")
+        .select("id, organiser_id, start_date, end_date, is_active, profiles:organiser_id(id, full_name, email)")
+        .eq("entity_type", "project")
+        .eq("entity_id", id as string)
+        .order("start_date", { ascending: false });
+      if (error) throw error;
+      return data || [];
+    },
+  });
+
+  // Fetch all organisers (to allocate)
+  const { data: organisers = [] } = useQuery({
+    queryKey: ["all-organisers"],
+    queryFn: async () => {
+      const { data, error } = await supabase
+        .from("profiles")
+        .select("id, full_name, email, role")
+        .in("role", ["organiser", "lead_organiser"]);
+      if (error) throw error;
+      return data || [];
+    },
+  });
+
+  // Quick role check for UI actions
+  const { data: canAllocate } = useQuery({
+    queryKey: ["can-allocate", user?.id],
+    enabled: !!user?.id,
+    queryFn: async () => {
+      // Lead organisers and admins can allocate
+      const { data } = await supabase.rpc("has_role", { _user_id: user!.id, _role: "lead_organiser" });
+      const { data: isAdmin } = await supabase.rpc("is_admin");
+      return Boolean(data) || Boolean(isAdmin);
+    },
+  });
+
+  const [allocOrganiserId, setAllocOrganiserId] = useState<string>("");
+  const [allocating, setAllocating] = useState(false);
+
+  const allocateOrganiser = async () => {
+    if (!id || !allocOrganiserId) return;
+    setAllocating(true);
+    try {
+      const { error } = await supabase.from("organiser_allocations").insert({
+        organiser_id: allocOrganiserId,
+        entity_type: "project",
+        entity_id: id,
+        allocated_by: user?.id || null,
+      });
+      if (error) throw error;
+      toast.success("Organiser allocated to project");
+      setAllocOrganiserId("");
+      await refetchAllocations();
+    } catch (e: any) {
+      toast.error(e.message || "Failed to allocate organiser");
+    } finally {
+      setAllocating(false);
+    }
+  };
 
   const { data: jobSites } = useQuery({
     queryKey: ["project-sites", project?.id],
@@ -399,6 +467,40 @@ const ProjectDetail = () => {
               <div>
                 <div className="text-xs text-muted-foreground">Project Value</div>
                 <div className="font-medium">{project?.value ? new Intl.NumberFormat('en-AU', { style: 'currency', currency: 'AUD', maximumFractionDigits: 0 }).format(Number(project.value)) : '-'}</div>
+              </div>
+            </div>
+            <div className="mt-6">
+              <div className="text-xs text-muted-foreground mb-2">Organiser Allocations</div>
+              <div className="flex flex-col gap-3">
+                <div className="flex flex-wrap gap-2">
+                  {(organiserAllocations as any[]).map((oa) => (
+                    <Badge key={oa.id} variant={oa.is_active ? "default" : "secondary"}>
+                      {oa.profiles?.full_name || oa.profiles?.email || oa.organiser_id}
+                    </Badge>
+                  ))}
+                  {organiserAllocations.length === 0 && (
+                    <span className="text-sm text-muted-foreground">No organisers allocated yet.</span>
+                  )}
+                </div>
+                {canAllocate && (
+                  <div className="flex items-center gap-2">
+                    <Select value={allocOrganiserId} onValueChange={setAllocOrganiserId}>
+                      <SelectTrigger className="w-64">
+                        <SelectValue placeholder="Select organiser" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {(organisers as any[]).map((o) => (
+                          <SelectItem key={o.id} value={o.id}>
+                            {o.full_name || o.email}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                    <Button onClick={allocateOrganiser} disabled={allocating || !allocOrganiserId}>
+                      {allocating ? "Allocating..." : "Allocate"}
+                    </Button>
+                  </div>
+                )}
               </div>
             </div>
           </CardContent>

--- a/supabase/migrations/20250812095000_organiser_allocations_access_functions.sql
+++ b/supabase/migrations/20250812095000_organiser_allocations_access_functions.sql
@@ -1,0 +1,186 @@
+-- 1) Optimise organiser_allocations lookups
+CREATE INDEX IF NOT EXISTS idx_oa_organiser_entity_active_dates
+ON public.organiser_allocations (organiser_id, entity_type, is_active, start_date, end_date);
+
+-- Helper: check if an allocation row is currently active
+CREATE OR REPLACE FUNCTION public.is_allocation_active(_start date, _end date)
+RETURNS boolean
+LANGUAGE sql
+STABLE
+AS $$
+  SELECT _start <= CURRENT_DATE AND (_end IS NULL OR _end >= CURRENT_DATE);
+$$;
+
+-- 2) Accessible projects via organiser_allocations and hierarchy
+CREATE OR REPLACE FUNCTION public.get_accessible_projects(user_id uuid)
+RETURNS TABLE(project_id uuid)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $function$
+  -- Admins see all projects
+  SELECT p.id AS project_id
+  FROM public.projects p
+  WHERE public.is_admin()
+
+  UNION
+
+  -- Direct project allocations for this organiser
+  SELECT oa.entity_id AS project_id
+  FROM public.organiser_allocations oa
+  WHERE oa.entity_type = 'project'
+    AND oa.is_active
+    AND public.is_allocation_active(oa.start_date, oa.end_date)
+    AND oa.organiser_id = user_id
+
+  UNION
+
+  -- Lead organisers see their subordinate organisers' project allocations
+  SELECT oa.entity_id AS project_id
+  FROM public.organiser_allocations oa
+  WHERE oa.entity_type = 'project'
+    AND oa.is_active
+    AND public.is_allocation_active(oa.start_date, oa.end_date)
+    AND public.has_role(user_id, 'lead_organiser')
+    AND public.is_lead_of(user_id, oa.organiser_id)
+
+  UNION
+
+  -- Back-compat: legacy organiser_projects table (if still populated)
+  SELECT op.project_id
+  FROM public.organiser_projects op
+  WHERE op.organiser_id = user_id
+
+  UNION
+
+  SELECT op.project_id
+  FROM public.organiser_projects op
+  WHERE public.has_role(user_id, 'lead_organiser')
+    AND public.is_lead_of(user_id, op.organiser_id);
+$function$;
+
+-- 3) Accessible job sites via allocations and project access
+CREATE OR REPLACE FUNCTION public.get_accessible_job_sites(user_id uuid)
+RETURNS TABLE(job_site_id uuid)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $function$
+  -- Admins see all sites
+  SELECT js.id AS job_site_id
+  FROM public.job_sites js
+  WHERE public.is_admin()
+
+  UNION
+
+  -- Direct job site allocations for this organiser
+  SELECT oa.entity_id AS job_site_id
+  FROM public.organiser_allocations oa
+  WHERE oa.entity_type = 'job_site'
+    AND oa.is_active
+    AND public.is_allocation_active(oa.start_date, oa.end_date)
+    AND oa.organiser_id = user_id
+
+  UNION
+
+  -- Lead organisers see their subordinate organisers' job site allocations
+  SELECT oa.entity_id AS job_site_id
+  FROM public.organiser_allocations oa
+  WHERE oa.entity_type = 'job_site'
+    AND oa.is_active
+    AND public.is_allocation_active(oa.start_date, oa.end_date)
+    AND public.has_role(user_id, 'lead_organiser')
+    AND public.is_lead_of(user_id, oa.organiser_id)
+
+  UNION
+
+  -- Sites from accessible projects
+  SELECT js.id AS job_site_id
+  FROM public.job_sites js
+  WHERE js.project_id IN (
+    SELECT project_id FROM public.get_accessible_projects(user_id)
+  )
+
+  UNION
+
+  -- Back-compat: legacy organiser_job_sites table (if still populated)
+  SELECT ojs.job_site_id
+  FROM public.organiser_job_sites ojs
+  WHERE ojs.organiser_id = user_id
+
+  UNION
+
+  SELECT ojs.job_site_id
+  FROM public.organiser_job_sites ojs
+  WHERE public.has_role(user_id, 'lead_organiser')
+    AND public.is_lead_of(user_id, ojs.organiser_id);
+$function$;
+
+-- 4) Accessible employers derived from accessible projects and job sites, plus direct allocations
+CREATE OR REPLACE FUNCTION public.get_accessible_employers(user_id uuid)
+RETURNS TABLE(employer_id uuid)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $function$
+  -- Admins see all employers
+  SELECT e.id AS employer_id FROM public.employers e WHERE public.is_admin()
+
+  UNION
+
+  -- From project-level roles
+  SELECT DISTINCT per.employer_id
+  FROM public.project_employer_roles per
+  WHERE per.employer_id IS NOT NULL
+    AND per.project_id IN (
+      SELECT project_id FROM public.get_accessible_projects(user_id)
+    )
+
+  UNION
+
+  -- From site contractor trades (if present)
+  SELECT DISTINCT sct.employer_id
+  FROM public.site_contractor_trades sct
+  JOIN public.job_sites js ON js.id = sct.job_site_id
+  WHERE sct.employer_id IS NOT NULL
+    AND js.id IN (
+      SELECT job_site_id FROM public.get_accessible_job_sites(user_id)
+    )
+
+  UNION
+
+  -- Direct employer allocations
+  SELECT oa.entity_id AS employer_id
+  FROM public.organiser_allocations oa
+  WHERE oa.entity_type = 'employer'
+    AND oa.is_active
+    AND public.is_allocation_active(oa.start_date, oa.end_date)
+    AND (
+      oa.organiser_id = user_id OR
+      (public.has_role(user_id, 'lead_organiser') AND public.is_lead_of(user_id, oa.organiser_id))
+    );
+$function$;
+
+-- 5) Accessible workers via placements on accessible job sites
+CREATE OR REPLACE FUNCTION public.get_accessible_workers(user_id uuid)
+RETURNS TABLE(worker_id uuid)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $function$
+  -- Admins see all workers
+  SELECT w.id AS worker_id FROM public.workers w WHERE public.is_admin()
+
+  UNION
+
+  -- Workers placed on accessible job sites (current and historical)
+  SELECT DISTINCT wp.worker_id
+  FROM public.worker_placements wp
+  WHERE wp.job_site_id IN (
+    SELECT job_site_id FROM public.get_accessible_job_sites(user_id)
+  );
+$function$;


### PR DESCRIPTION
Adds Supabase functions to derive accessible projects, job sites, employers, and workers based on organiser allocations and role hierarchy.

This change implements the core logic for linking employers, job sites, and workers to organisers via the `organiser_allocations` table. It provides new RPC functions that allow administrators and lead organisers to view entities managed by their subordinates, and all users to see entities they are directly allocated to, fulfilling the requirement for comprehensive access control based on organiser assignments.

---
<a href="https://cursor.com/background-agent?bcId=bc-62a96376-8d15-4d08-a7ea-78040462d9d0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-62a96376-8d15-4d08-a7ea-78040462d9d0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

