### PR TITLE
Fix duplicate identifier in admin page

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -15,17 +15,17 @@ export default function AdminPage() {
   const supabase = supabaseBrowser();
   const { toast } = useToast();
   const router = useRouter();
-  const { role, isLoading } = useProfileRole();
+  const { role, isLoading: isRoleLoading } = useProfileRole();
   const [inviteEmail, setInviteEmail] = useState("");
   const [sending, setSending] = useState(false);
   const [search, setSearch] = useState("");
 
   useEffect(() => {
-    if (isLoading) return;
+    if (isRoleLoading) return;
     if (role !== "admin") {
       router.replace("/dashboard");
     }
-  }, [isLoading, role, router]);
+  }, [isRoleLoading, role, router]);
 
   const sendInvite = async () => {
     setSending(true);


### PR DESCRIPTION
Rename `isLoading` from `useProfileRole` to `isRoleLoading` to resolve a duplicate identifier build error.

---
<a href="https://cursor.com/background-agent?bcId=bc-dc0b2a1d-26ff-4797-bee5-4772ef2905c0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-dc0b2a1d-26ff-4797-bee5-4772ef2905c0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

